### PR TITLE
Update onBrokenLinks config to warn in Docusaurus setup

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
   organizationName: 'Field-Day-2022', // Usually your GitHub org/user name.
   projectName: 'field-day-2022.github.io', // Usually your repo name.
 
-  onBrokenLinks: 'throw',
+  onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
 
   i18n: {


### PR DESCRIPTION
Changed the onBrokenLinks setting in Docusaurus configuration from 'throw' to 'warn'. This alteration ensures that the site compilation process logs a warning instead of throwing an error when broken links are encountered, facilitating a smoother build process during development.

Release-Note: Change the onBrokenLinks configuration to 'warn' instead of 'throw' to handle broken links more gracefully.