### PR TITLE
Add GitHub logo import and refactor publications list in docs

### DIFF
--- a/docs/feedback.mdx
+++ b/docs/feedback.mdx
@@ -5,6 +5,7 @@ sidebar_position: 4
 ---
 
 import Admonition from '@theme/Admonition';
+import GitHubLogo from '@site/static/img/github/github-mark.png';
 
 ## Introduction
 
@@ -14,7 +15,7 @@ Welcome to the Field Day feedback and issue reporting guide. This document will 
 
 GitHub is a tool for software developers, but you don't need to be a developer to use it. It's a user-friendly platform that allows you to report issues, request features, and provide feedback on the Field Day project.
 
-![GitHub Logo](../static/img/github/github-mark.png)
+<img src={GitHubLogo} alt="GitHub Logo" width="150" />
 
 GitHub is a platform for version control and collaboration. It allows multiple people to work on projects simultaneously, track changes, and manage different versions of the project. To report issues or request features for Field Day, you will need a GitHub account. Don't worry, it's free and easy to sign up.
 

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -16,13 +16,15 @@ Terms marked with a 🖥️ symbol are related to software engineering, while te
 
 ### A
 
-<GlossaryEntry term="Antora 🖥️" definition="Antora is a documentation site generator for tech writers who create documentation sites from AsciiDoc content. It is used to build the Field Day documentation site." field="software" />
-
 <GlossaryEntry term="AsciiDoc 🖥️" definition="AsciiDoc is a lightweight markup language used to write documentation. It is similar to Markdown but offers more features." field="software" />
 
 ### C
 
 <GlossaryEntry term="Capture Mark Recapture (CMR) 🐾" definition="A method used in wildlife biology to estimate an animal population's size. It involves capturing animals, marking them, releasing them, and then recapturing them to see how many marked animals are found." field="biology" />
+
+### D
+
+<GlossaryEntry term="Docusaurus 🖥️" definition="Docusaurus is a project for building, deploying, and maintaining open source project websites easily. It is used to build the Field Day documentation site." field="software" />
 
 ### G
 
@@ -33,8 +35,6 @@ Terms marked with a 🖥️ symbol are related to software engineering, while te
 <GlossaryEntry term="Google Firebase 🖥️" definition="Google Firebase is a platform developed by Google for creating mobile and web applications. It provides a variety of tools and services to help developers build high-quality apps." field="software" />
 
 <GlossaryEntry term="Google Firestore 🖥️" definition="Google Firestore is a flexible, scalable database for mobile, web, and server development from Firebase and Google Cloud Platform. It is used to store and sync data for client- and server-side development." field="software" />
-
-<GlossaryEntry term="Gulp 🖥️" definition="Gulp is a toolkit for automating painful or time-consuming tasks in your development workflow. It is used in the Field Day project for tasks such as live previewing and building the site." field="software" />
 
 ### I
 
@@ -52,9 +52,13 @@ Terms marked with a 🖥️ symbol are related to software engineering, while te
 
 ### P
 
+<GlossaryEntry term="Progressive Web App (PWA) 🖥️" definition="A Progressive Web App (PWA) is a type of application software delivered through the web, built using common web technologies including HTML, CSS, and JavaScript. It is intended to work on any platform that uses a standards-compliant browser." field="software" />
+
 <GlossaryEntry term="Pull Request 🖥️" definition="A pull request is a method of submitting contributions to a project. It is a request to merge code changes into the main project repository." field="software" />
 
 ### R
+
+<GlossaryEntry term="React 🖥️" definition="React is a JavaScript library for building user interfaces. It is maintained by Facebook and a community of individual developers and companies." field="software" />
 
 <GlossaryEntry term="Repository 🖥️" definition="A repository is a central location in which data is stored and managed. In GitHub, a repository is used to organize a single project." field="software" />
 

--- a/src/components/GlossaryEntry.module.css
+++ b/src/components/GlossaryEntry.module.css
@@ -1,6 +1,6 @@
 :root {
 	--background-color-light: #f9f9f9;
-	--background-color-dark: #333;
+	--background-color-dark: #222;
 	--border-color-light: #ddd;
 	--border-color-dark: #555;
 	--text-color-light: #000;

--- a/src/components/HomepageApps/index.tsx
+++ b/src/components/HomepageApps/index.tsx
@@ -12,6 +12,7 @@ type AppItem = {
   description: ReactNode;
   guideLink: string;
   repoLink: string;
+  appLink: string; // New property for app deployment link
 };
 
 const AppList: AppItem[] = [
@@ -25,6 +26,7 @@ const AppList: AppItem[] = [
     ),
     guideLink: '/docs/mobile-data-collector',
     repoLink: 'https://github.com/Field-Day-2022/mobile-data-collector',
+    appLink: 'https://asu-field-day-pwa.web.app/', // Example link
   },
   {
     title: '💻 Desktop Data Manager',
@@ -36,19 +38,22 @@ const AppList: AppItem[] = [
     ),
     guideLink: '/docs/desktop-data-manager',
     repoLink: 'https://github.com/Field-Day-2022/desktop-data-manager',
+    appLink: 'https://asu-field-day-webui.web.app/login', // Example link
   },
 ];
 
-function AppItem({title, Img, description, guideLink, repoLink}: AppItem) {
+function AppItem({title, Img, description, guideLink, repoLink, appLink}: AppItem) {
   return (
     <div className={clsx('col col--6', styles.appItem)}>
-      <div className="text--center">
+      <div className={clsx('text--center', styles.imageContainer)}>
         <img src={Img} className={styles.appImg} role="img" alt={title} />
       </div>
       <div className="text--center padding-horiz--md">
-        <Heading as="h3">{title}</Heading>
+        <Heading as="h3">
+          <Link to={appLink}>{title}</Link>
+        </Heading>
         <p>{description}</p>
-        <div className={styles.links}>
+        <div className={styles.buttonContainer}>
           <Link className={clsx('button button--primary button--md', styles.button)} to={guideLink}>
             📖 User Guide
           </Link>

--- a/src/components/HomepageApps/styles.module.css
+++ b/src/components/HomepageApps/styles.module.css
@@ -15,54 +15,46 @@
   height: 100%;
 }
 
+.imageContainer {
+  position: relative;
+  display: inline-block;
+}
+
 .appImg {
   width: 100%;
-  max-width: 500px;
+  max-width: 400px;
   margin-bottom: 1rem;
 }
 
 .links {
   display: flex;
+  flex-direction: column;
   gap: 1rem;
   justify-content: center;
   margin-top: auto;
 }
 
-.button {
-  padding: 0.75rem 1.5rem;
-  font-size: 1rem;
-  border-radius: 8px;
-  transition: background-color 0.3s, transform 0.3s;
+@media (min-width: 768px) {
+  .links {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
 }
 
-.button--primary {
-  background-color: #007bff;
-  color: #fff;
-  border: none;
+.buttonContainer {
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
 }
 
-.button--primary:hover {
-  background-color: #0056b3;
-  transform: translateY(-2px);
-}
-
-.button--primary:active {
-  background-color: #004494;
-  transform: translateY(0);
-}
-
-.button--secondary {
-  background-color: #28a745;
-  color: #fff;
-  border: none;
-}
-
-.button--secondary:hover {
-  background-color: #218838;
-  transform: translateY(-2px);
-}
-
-.button--secondary:active {
-  background-color: #1e7e34;
-  transform: translateY(0);
+@media (min-width: 768px) {
+  .buttonContainer {
+    flex-direction: row;
+    justify-content: center;
+  }
 }

--- a/src/components/PublicationEntry.module.css
+++ b/src/components/PublicationEntry.module.css
@@ -1,0 +1,51 @@
+:root {
+    --background-color-light: #f9f9f9;
+    --background-color-dark: #222;
+    --border-color-light: #ddd;
+    --border-color-dark: #555;
+    --text-color-light: #000;
+    --text-color-dark: #fff;
+  }
+  
+  [data-theme='dark'] {
+    --background-color: var(--background-color-dark);
+    --border-color: var(--border-color-dark);
+    --text-color: var(--text-color-dark);
+  }
+  
+  [data-theme='light'] {
+    --background-color: var(--background-color-light);
+    --border-color: var(--border-color-light);
+    --text-color: var(--text-color-light);
+  }
+  
+  .publicationCard {
+    background-color: var(--background-color);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    margin-bottom: 1rem;
+  }
+  
+  .publicationCard h3 {
+    margin-top: 0;
+  }
+  
+  .publicationCard a {
+    text-decoration: none;
+  }
+  
+  .publicationCard a:hover {
+    text-decoration: underline;
+  }
+  
+  .source, .authors, .date {
+    margin: 0.5rem 0;
+  }
+  
+  @media (max-width: 768px) {
+    .authors, .date {
+      display: none;
+    }
+  }

--- a/src/components/PublicationEntry.tsx
+++ b/src/components/PublicationEntry.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styles from './PublicationEntry.module.css';
+
+interface PublicationEntryProps {
+  title: string;
+  source: string;
+  authors: string;
+  date: string;
+  link: string;
+}
+
+const PublicationEntry: React.FC<PublicationEntryProps> = ({ title, source, authors, date, link }) => {
+  return (
+    <div className={styles.publicationCard}>
+      <h3 className={styles.title}>
+        <a href={link} target="_blank" rel="noopener noreferrer">
+          {title}
+        </a>
+      </h3>
+      <p className={styles.source}>{source}</p>
+      <p className={styles.authors}>{authors}</p>
+      <p className={styles.date}>{date}</p>
+    </div>
+  );
+};
+
+export default PublicationEntry;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,6 +15,22 @@
   --ifm-color-primary-lightest: #c95d84; /* Lightest Maroon */
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  --ifm-color-secondary: #d0d0d0; /* ASU Gray 5 */
+  --ifm-color-secondary-dark: #bfbfbf; /* ASU Gray 4 */
+  --ifm-color-secondary-darker: #a0a0a0; /* Slightly Darker Gray */
+  --ifm-color-secondary-darkest: #8f8f8f; /* Even Darker Gray */
+  --ifm-color-secondary-light: #e8e8e8; /* ASU Gray 6 */
+  --ifm-color-secondary-lighter: #f0f0f0; /* Lighter Gray */
+  --ifm-color-secondary-lightest: #fafafa; /* Lightest Gray */
+
+  --ifm-color-warning: #ffc627; /* ASU Gold */
+  --ifm-color-warning-dark: #e6b323; /* Dark Gold */
+  --ifm-color-warning-darker: #cc9f1f; /* Darker Gold */
+  --ifm-color-warning-darkest: #b38b1b; /* Darkest Gold */
+  --ifm-color-warning-light: #ffd54f; /* Light Gold */
+  --ifm-color-warning-lighter: #ffe082; /* Lighter Gold */
+  --ifm-color-warning-lightest: #ffecb3; /* Lightest Gold */
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -27,4 +43,10 @@
   --ifm-color-primary-lighter: #c95d84; /* Lightest Maroon */
   --ifm-color-primary-lightest: #d97b9b; /* Even Lighter Maroon */
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+}
+
+img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }

--- a/src/pages/Publications.tsx
+++ b/src/pages/Publications.tsx
@@ -1,54 +1,40 @@
 import React from 'react';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
+import PublicationEntry from '../components/PublicationEntry';
+
+const publications = [
+  {
+    title: 'Mobile app for wildlife capture-mark-recapture data collection and query',
+    source: 'Wildlife Society Bulletin, Volume 37, Issue 4',
+    authors: 'Heather L. Bateman, Timothy E. Lindquist, Richard Whitehouse, Maria M. Gonzalez',
+    date: 'August 23, 2013',
+    link: 'http://onlinelibrary.wiley.com/doi/10.1002/wsb.322/abstract',
+  },
+  {
+    title: 'Biologists Ditch Traditional Methods in Favor of New Record-Keeping App',
+    source: 'ASU News',
+    authors: 'Sydney B. Donaldson',
+    date: 'August 26, 2013',
+    link: 'https://news.asu.edu/content/biologists-ditch-traditional-methods-favor-new-record-keeping-app',
+  },
+  {
+    title: 'ASU Innovation Showcase 2023',
+    source: 'ASU Innovation Showcase',
+    authors: 'Isaiah Lathem, Ian Skelskey, Jack Norman, Zachary Jacobson, Dennis Grassl',
+    date: 'Spring, 2023',
+    link: '/img/innovation-showcase-2023.png',
+  },
+];
 
 export default function Publications(): JSX.Element {
   return (
     <Layout title="Publications" description="Publications related to the Field Day project">
       <div className="container margin-vert--lg">
         <Heading as="h1">Publications</Heading>
-        <table className="table">
-          <thead>
-            <tr>
-              <th>Title</th>
-              <th>Source</th>
-              <th>Authors</th>
-              <th>Date</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <a href="http://onlinelibrary.wiley.com/doi/10.1002/wsb.322/abstract" target="_blank" rel="noopener noreferrer">
-                  Mobile app for wildlife capture-mark-recapture data collection and query
-                </a>
-              </td>
-              <td>Wildlife Society Bulletin, Volume 37, Issue 4</td>
-              <td>Heather L. Bateman, Timothy E. Lindquist, Richard Whitehouse, Maria M. Gonzalez</td>
-              <td>August 23, 2013</td>
-            </tr>
-            <tr>
-              <td>
-                <a href="https://news.asu.edu/content/biologists-ditch-traditional-methods-favor-new-record-keeping-app" target="_blank" rel="noopener noreferrer">
-                  Biologists Ditch Traditional Methods in Favor of New Record-Keeping App
-                </a>
-              </td>
-              <td>ASU News</td>
-              <td>Sydney B. Donaldson</td>
-              <td>August 26, 2013</td>
-            </tr>
-            <tr>
-			  <td>
-				<a href="/img/innovation-showcase-2023.png" target="_blank" rel="noopener noreferrer">
-				  ASU Innovation Showcase 2023
-				</a>
-			  </td>
-              <td>ASU Innovation Showcase</td>
-              <td>Isaiah Lathem, Ian Skelskey, Jack Norman, Zachary Jacobson, Dennis Grassl</td>
-              <td>Spring, 2023</td>
-            </tr>
-          </tbody>
-        </table>
+        {publications.map((publication, idx) => (
+          <PublicationEntry key={idx} {...publication} />
+        ))}
       </div>
     </Layout>
   );

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -18,26 +18,3 @@
   gap: 1rem;
   margin-top: 2rem;
 }
-
-.button {
-  padding: 0.75rem 1.5rem;
-  font-size: 1.25rem;
-  border-radius: 8px;
-  transition: background-color 0.3s, transform 0.3s;
-}
-
-.button--secondary {
-  background-color: #007bff;
-  color: #fff;
-  border: none;
-}
-
-.button--secondary:hover {
-  background-color: #0056b3;
-  transform: translateY(-2px);
-}
-
-.button--secondary:active {
-  background-color: #004494;
-  transform: translateY(0);
-}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,12 +19,12 @@ function HomepageHeader() {
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <div className={styles.buttons}>
           <Link
-            className={clsx('button button--secondary button--lg', styles.button)}
+            className={clsx('button button--secondary', styles.button)}
             to="/about">
             📖 Learn More
           </Link>
           <Link
-            className={clsx('button button--secondary button--lg', styles.button)}
+            className={clsx('button button--secondary', styles.button)}
             to="/docs/feedback">
             💬 Contribute
           </Link>


### PR DESCRIPTION
- Introduced a GitHub logo import in `feedback.mdx` for consistent image handling.
- Converted publication entries from a table to use a new `PublicationEntry` component for cleaner code organization.
- Updated glossary with terms like \"Docusaurus\" and removed Gulp for accuracy.
- Improved app list in `HomepageApps` with deployment links for better user navigation.
- Enhanced CSS for button and layout styling for a more responsive design.

Release-Note: Enhance design elements with consistent styling and improve user navigation through better component management.